### PR TITLE
Add Infectious Diseased Immunity to Stench

### DIFF
--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Goals/lx_talents.txt
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Goals/lx_talents.txt
@@ -49,6 +49,13 @@ CharacterHasTalent(_Char, "Stench", 1)
 THEN
 NRD_StatusPreventApply(_Char, _Handle, 1);
 
+IF
+NRD_OnStatusAttempt((CHARACTERGUID)_Char, "INFECTIOUS_DISEASED", _Handle, _)
+AND
+CharacterHasTalent(_Char, "Stench", 1)
+THEN
+NRD_StatusPreventApply(_Char, _Handle, 1);
+
 //// Pet Pal summon debuff
 IF
 CharacterStatusApplied((CHARACTERGUID)_Summon, "SUMMONING_ABILITY", _)


### PR DESCRIPTION
Infectious Diseased is a status that has the same effect as diseased but can spread disease. Characters with Stench should also have immunity to this, as it is applied by the spell "Infect".