### PR TITLE
damage handling now hits within a continuous range after mulitplications, tooltips localisable

### DIFF
--- a/Editor/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Stats/ExtraData/Data.stats
+++ b/Editor/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Stats/ExtraData/Data.stats
@@ -455,5 +455,12 @@
         <field name="Value" type="FloatStatObjectFieldDefinition" value="8" />
       </fields>
     </stat_object>
+    <stat_object is_substat="false">
+      <fields>
+        <field name="Name" type="NameStatObjectFieldDefinition" value="DGM_RangedCQBPenaltyRange" />
+        <field name="Value" type="FloatStatObjectFieldDefinition" value="2" />
+        <field name="Comment" type="CommentStatObjectFieldDefinition" value="In meters, the range at which being closer causes the penalty" />
+      </fields>
+    </stat_object>
   </stat_objects>
 </stats>

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Localization/English/english.xml
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Localization/English/english.xml
@@ -67,4 +67,11 @@
     <content contentuid="hda7ee9a4g5bbeg4c62g96b7ge31b21e094f3" comment="Two handed dynamic tooltip new">Next Level [1]: +[2]% Damage, +[3]% Critical Multiplier and [4]% Accuracy.</content>
     <content contentuid="h5d0c3ad0g3d9dg4cf1g92b7g20d6d7d26344" comment="Perseverance dyanmic tooltip current">Level [1]: +[2]% Armour and +[3]% Vitality restored after a hard Crowd Control effect recovery.</content>
     <content contentuid="h443a51dcgbd6fg46c2g8988gbfe93a3123a5" comment="Perseverance dyanmic tooltip new">Next Level [1]: +[2]% Armour and +[3]% Vitality restored after a hard Crowd Control effect recovery.</content>
+    <content contentuid="h1e5caa33g4d5dg4f42g91edg9f546d42f56b" comment="Staff dynamic tooltip">Increases all Skill damage by [1]%.</content>
+    <content contentuid="h314ee256g43cdg4864ga519gd23e909ec63e" comment="Wand dynamic tooltip">Increase all Skill damage by [1]% (stackable when dual-wielding)</content>
+    <content contentuid="h3e8d0f43g5060g48d8g95cag541abe3a7c08" comment="Ranged weapons dynamic tooltip">Receive a [1]% Damage penalty if the target is closer than [2] meters</content>
+    <content contentuid="hdf2a4bd0g134eg4107g9a8agd93d6d22fd68" comment="Attribute general bonus dynamic tooltip">From Attributes : [1]%</content>
+    <content contentuid="ha418e064g2d69g4407gadc2gf2f590f0e895" comment="Strength weapond damage dynamic tooltip">From Strength weapon bonus : [1]%</content>
+    <content contentuid="hf338b2c0gd158g49b4ga2ceg15a7099a4b7b" comment="Intelligence skill damage dynamic tooltip">Skills gets a bonus of +[1]% from Intelligence</content>
+    <content contentuid="h092684e6gbf69g4372g99f8g4743516b0efe" comment="Dual wielding penalty dynamic tooltip">Offhand penalty: [1]% (penalty reduced by [2]% from Dual-Wielding)</content>
 </contentList>

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
@@ -1,12 +1,12 @@
----@param target EsvCharacter
+---@param target EsvCharacter|EsvItem
 ---@param handle number
----@param instigator EsvCharacter
+---@param instigator EsvCharacter|EsvItem
 function DamageControl(target, handle, instigator)
 	--[[
 		Main damage control : damages are teared down to the original formula and apply custom
 		bonuses from the overhaul
 	]]--
-	if ObjectIsCharacter(instigator) == 0 then return end
+	if ObjectIsCharacter(instigator) == 0 or ObjectIsCharacter(target) == 0 then return end
 	-- Get hit properties
 	local damages = {}
 	local types = DamageTypeEnum()
@@ -61,9 +61,9 @@ function DamageControl(target, handle, instigator)
 	end
 		
 	-- Get instigator bonuses
-	local strength = CharacterGetAttribute(instigator, "Strength") - 10
-	local finesse = CharacterGetAttribute(instigator, "Finesse") - 10
-	local intelligence = CharacterGetAttribute(instigator, "Intelligence") - 10
+	local strength = CharacterGetAttribute(instigator, "Strength") - Ext.ExtraData.AttributeBaseValue
+	local finesse = CharacterGetAttribute(instigator, "Finesse") - Ext.ExtraData.AttributeBaseValue
+	local intelligence = CharacterGetAttribute(instigator, "Intelligence") - Ext.ExtraData.AttributeBaseValue
 	local damageBonus = strength*Ext.ExtraData.DGM_StrengthGlobalBonus+finesse*Ext.ExtraData.DGM_FinesseGlobalBonus+intelligence*Ext.ExtraData.DGM_IntelligenceGlobalBonus -- /!\ Remember that 1=1% in this variable
 	local globalMultiplier = 1.0
 	

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
@@ -81,7 +81,7 @@ function DamageControl(target, handle, instigator)
 		if weaponTypes[1] == "Bow" or weaponTypes[1] == "Crossbow" or weaponTypes[1] == "Rifle" or weaponTypes[1] == "Wand" then
 			local distance = GetDistanceTo(target, instigator)
 			--Ext.Print("[LXDGM_DamageControl.DamageControl] Distance :",distance)
-			if distance <= 2.0 and CharacterHasTalent(instigator, "RangerLoreArrowRecover") == 0 then
+			if distance <= Ext.ExtraData.DGM_RangedCQBPenaltyRange and CharacterHasTalent(instigator, "RangerLoreArrowRecover") == 0 then
 				globalMultiplier = globalMultiplier - (Ext.ExtraData.DGM_RangedCQBPenalty/100)
 			end
 		end

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_DamageControl.lua
@@ -23,9 +23,9 @@ function DamageControl(target, handle, instigator)
 	local fromReflection = NRD_StatusGetInt(target, handle, "Reflection")
 	-- print("Hit from reflection: "..fromReflection)
 	local hitType = NRD_StatusGetInt(target, handle, "DoT")
-	--print("HitType: "..hitType)
+	-- print("HitType: "..hitType)
 	local sourceType = NRD_StatusGetInt(target, handle, "DamageSourceType")
-	local skillID = NRD_StatusGetString(target, handle, "SkillId")
+	local skillID = NRD_StatusGetString(target, handle, "SkillId"):gsub("_%-?%d+$", "")
 	local backstab = NRD_StatusGetInt(target, handle, "Backstab")
 	local fixedValue = 0
 	-- print("SkillID: "..skillID)
@@ -126,7 +126,13 @@ function DamageControl(target, handle, instigator)
 	end
 	
 	-- Apply damage changes and side effects
-	damages = ChangeDamage(damages, (damageBonus/100+1)*globalMultiplier, 0, instigator)
+	local randomMultiplier = 1.0
+	if skillID ~= "" then
+		local damageRange = Ext.StatGetAttribute(skillID, "Damage Range") or 0.0
+		randomMultiplier = 1.0 + (Ext.Random(0, damageRange) - damageRange/2) * 0.01
+	end
+	damages = ChangeDamage(damages, (damageBonus/100+1)*globalMultiplier*randomMultiplier, 0, instigator)
+	
 	ReplaceDamages(damages, handle, target)
 	SetWalkItOff(target, handle)
 	
@@ -158,6 +164,7 @@ function ChangeDamage(damages, multiplier, value, instigator)
 		end
 		amount = amount * multiplier
 		amount = amount + value
+		amount = Ext.Round(amount)
 		if amount ~= 0 then print("Changed "..dmgType.." to "..amount.." (Multiplier = "..multiplier..")") end
 		damages[dmgType] = amount
 	end
@@ -264,4 +271,9 @@ local function DGM_HitChanceFormula(attacker, target)
     return hitChance
 end
 
+local function GetSkillDamage(skill, attacker, isFromItem, stealthed, attackerPos, targetPos, level, noRandomization)
+    return Game.Math.GetSkillDamage(skill, attacker, isFromItem, stealthed, attackerPos, targetPos, level, true)
+end
+
 Ext.RegisterListener("GetHitChance", DGM_HitChanceFormula)
+Ext.RegisterListener("GetSkillDamage", GetSkillDamage)

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_Helpers.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_Helpers.lua
@@ -24,6 +24,19 @@ function round(number, precision)
 	return result
 end
 
+function dump(o)
+	if type(o) == 'table' then
+	   local s = '{ '
+	   for k,v in pairs(o) do
+		  if type(k) ~= 'number' then k = '"'..k..'"' end
+		  s = s .. '['..k..'] = ' .. dump(v) .. ','
+	   end
+	   return s .. '} '
+	else
+	   return tostring(o)
+	end
+ end
+
 ---@param char EsvCharacter
 ---@param next integer
 function CharGetDGMAttributeBonus(char, next)

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_Tooltips.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/LXDGM_Tooltips.lua
@@ -1,3 +1,50 @@
+local dynamicTooltips       = {
+    ["Strength"]            = "he1708d1eg243dg4b72g8f48gddb9bc8d62ff",
+    ["Finesse"]             = "h2e87e6cfg0183g4968g8ec1g325614c7d9fa",
+    ["Intelligence"]        = "h58e777ddgd569g4c0dg8f58gece56cce053d",
+    ["Damage"]              = "h7fec5db8g58d3g4abbgab7ag03e19b542bef",
+    ["WpnStaff"]            = "h1e5caa33g4d5dg4f42g91edg9f546d42f56b",
+    ["WpnWand"]             = "h314ee256g43cdg4864ga519gd23e909ec63e",
+    ["WpnRanged"]           = "h3e8d0f43g5060g48d8g95cag541abe3a7c08",
+    ["Dual-Wielding"]       = "hc5d5552bg6b33g44c1gbb0cg8d55a101f081",
+    ["Dual-Wielding_Next"]  = "h2baa6ed9gdca0g4731gb999g098d9c2d90b0",
+    ["Ranged"]              = "he86bfd28ge123g42a4g8c0cg2f9bcd7d9e05", 
+    ["Ranged_Next"]         = "hffc37ae5g6651g4a60ga1c1g49d233cb1ca2",
+    ["Single-Handed"]       = "h70707bb2g5a48g4571g9a68ged2fe5a030ea", 
+    ["Single-Handed_Next"]  = "h2afdc1f0g4650g4ea9gafb7gb0c042367766",
+    ["Two-Handed"]          = "h6e9ec88dgcbb7g426bgb1d9g69df0240825a", 
+    ["Two-Handed_Next"]     = "hda7ee9a4g5bbeg4c62g96b7ge31b21e094f3",
+    ["Perseverance"]        = "h5d0c3ad0g3d9dg4cf1g92b7g20d6d7d26344", 
+    ["Perseverance_Next"]   = "h443a51dcgbd6fg46c2g8988gbfe93a3123a5",
+    ["AttrGenBonus"]        = "hdf2a4bd0g134eg4107g9a8agd93d6d22fd68",
+    ["StrWpnBonus"]         = "ha418e064g2d69g4407gadc2gf2f590f0e895",
+    ["IntSkillBonus"]       = "hf338b2c0gd158g49b4ga2ceg15a7099a4b7b",
+    ["DualWieldingPenalty"] = "h092684e6gbf69g4372g99f8g4743516b0efe"
+}
+
+---@param str string
+local function SubstituteString(str, ...)
+    local args = {...}
+    local result = str
+
+    for k, v in pairs(args) do
+        if v == math.floor(v) then v = math.floor(v) end -- Formatting integers to not show .0
+        result = result:gsub("%["..tostring(k).."%]", v)
+    end
+    return result
+end
+
+---@param dynamicKey string
+local function GetDynamicTranslationString(dynamicKey, ...)
+    local args = {...}
+    
+    local handle = dynamicTooltips[dynamicKey]
+
+    local str = Ext.GetTranslatedString(handle, "Handle Error!")
+    str = SubstituteString(str, table.unpack(args))
+    return str
+end
+
 ---@param item StatItem
 ---@param tooltip TooltipData
 local function WeaponTooltips(item, tooltip)
@@ -7,19 +54,28 @@ local function WeaponTooltips(item, tooltip)
 		Type = "ItemRequirement",
 		Label = "",
 		RequirementMet = true
-	}
-	if item.WeaponType == "Staff" then equipment["Label"] = "Increase Skill damages by 110%" end
-	if item.WeaponType == "Wand" then equipment["Label"] = "Increase Skill damages by 102.5% (stackable when dual-wielding)" end
-	if item.WeaponType == "Bow" or item.WeaponType == "Crossbow" or item.WeaponType == "Rifle" then equipment["Label"]="Get a 35% Damage penalty if the target is closer than 2 meters."; equipment["RequirementMet"]=false end
-	if equipment["Label"] ~= "" then tooltip:AppendElementAfter(equipment, "ExtraProperties") end
-	if item.WeaponType == "Wand" then
-		local equipment = {
-			Type = "ItemRequirement",
-			Label = "Get a 35% Damage penalty if the target is closer than 2 meters.",
-			RequirementMet = false
-		}
-		tooltip:AppendElementAfter(equipment, "ExtraProperties")
-	end
+    }
+
+    if item.WeaponType == "Staff" then
+        equipment["Label"] = GetDynamicTranslationString("WpnStaff", Ext.ExtraData.DGM_StaffSkillMultiplier)
+        tooltip:AppendElementAfter(equipment, "ExtraProperties")
+    end
+
+    if item.WeaponType == "Wand" then
+        equipment["Label"] = GetDynamicTranslationString("WpnWand", Ext.ExtraData.DGM_WandSkillMultiplier)
+        tooltip:AppendElementAfter(equipment, "ExtraProperties")
+    end
+
+    if item.WeaponType == "Bow" or item.WeaponType == "Crossbow" or item.WeaponType == "Rifle" or item.WeaponType == "Wand" then
+        local equipment = {
+            Type = "ItemRequirement",
+            Label = "",
+            RequirementMet = true
+        }
+        equipment["Label"] = GetDynamicTranslationString("WpnRanged", Ext.ExtraData.DGM_RangedCQBPenalty, Ext.ExtraData.DGM_RangedCQBPenaltyRange)
+        equipment["RequirementMet"] = false
+        tooltip:AppendElementAfter(equipment, "ExtraProperties")
+    end
 end
 
 ---@param character EsvCharacter
@@ -35,16 +91,17 @@ local function SkillAttributeTooltipBonus(character, skill, tooltip)
 
     local general = {
         Type = "StatsPercentageBoost",
-        Label = "From Attributes : +"..generalBonus.."%"
+        Label = GetDynamicTranslationString("AttrGenBonus", generalBonus)
     }
     local strength = {
         Type = "StatsPercentageBoost",
-        Label = "From Strength weapon bonus : +"..strengthBonus.."%"
+        Label = GetDynamicTranslationString("StrWpnBonus", strengthBonus)
     }
     local intelligence = {
         Type = "StatsPercentageBoost",
-        Label = "Skills gets a bonus of +"..intelligenceBonus.."% from Intelligence."
+        Label = GetDynamicTranslationString("IntSkillBonus", intelligenceBonus)
     }
+
     tooltip:AppendElementAfter(general, "StatsPercentageBoost")
     tooltip:AppendElementAfter(strength, "StatsPercentageBoost")
     tooltip:AppendElementAfter(intelligence, "StatsPercentageBoost")
@@ -52,66 +109,37 @@ local function SkillAttributeTooltipBonus(character, skill, tooltip)
     if not stats.MainWeapon.IsTwoHanded then
         if stats.OffHandWeapon ~= nil and stats.OffHandWeapon.WeaponType ~= "Shield" then
             local offhandPenalty = tooltip:GetElements("StatsPercentageMalus")
-            for i,j in pairs(offhandPenalty) do
-                local translatedKey = Ext.GetTranslatedString("he3980bf8gf554g4dd8g823cgf2ccb71036a6", "Offhand penalty: [1]%")
-                local finalPenalty = math.floor(Ext.ExtraData.DualWieldingDamagePenalty*100 - stats.DualWielding*(Ext.ExtraData.DualWieldingDamagePenalty*10))
-                if j.Label:find(translatedKey:gsub("%[1]%%", "")) ~= nil then
-                    local replacement = finalPenalty.."%% (penalty reduced by "..tostring(math.floor(stats.DualWielding*(Ext.ExtraData.DualWieldingDamagePenalty*10))).."%% from Dual-wielding)"
-                    j.Label = translatedKey:gsub("%[1]%%", replacement)
-                end
+
+            local finalPenalty = Ext.ExtraData.DualWieldingDamagePenalty*100 - stats.DualWielding * Ext.ExtraData.DGM_DualWieldingOffhandBonus
+
+            local reducedBy = Ext.ExtraData.DualWieldingDamagePenalty*100 - finalPenalty
+            
+            for _, offhandPenaltySub in pairs(offhandPenalty) do
+                offhandPenaltySub.Label = GetDynamicTranslationString("DualWieldingPenalty", finalPenalty, reducedBy)
             end
         end
     end
-end
-
-local dynamicTooltips = {
-    ["Strength"] = "he1708d1eg243dg4b72g8f48gddb9bc8d62ff",
-    ["Finesse"] = "h2e87e6cfg0183g4968g8ec1g325614c7d9fa",
-    ["Intelligence"] = "h58e777ddgd569g4c0dg8f58gece56cce053d",
-    ["Damage"] = "h7fec5db8g58d3g4abbgab7ag03e19b542bef",
-    ["Dual-Wielding"] = {current = "hc5d5552bg6b33g44c1gbb0cg8d55a101f081", new = "h2baa6ed9gdca0g4731gb999g098d9c2d90b0"},
-    ["Ranged"] = {current = "he86bfd28ge123g42a4g8c0cg2f9bcd7d9e05", new = "hffc37ae5g6651g4a60ga1c1g49d233cb1ca2"},
-    ["Single-Handed"] = {current = "h70707bb2g5a48g4571g9a68ged2fe5a030ea", new = "h2afdc1f0g4650g4ea9gafb7gb0c042367766"},
-    ["Two-Handed"] = {current = "h6e9ec88dgcbb7g426bgb1d9g69df0240825a", new = "hda7ee9a4g5bbeg4c62g96b7ge31b21e094f3"},
-    ["Perseverance"] = {current = "h5d0c3ad0g3d9dg4cf1g92b7g20d6d7d26344", new = "h443a51dcgbd6fg46c2g8988gbfe93a3123a5"}
-}
-
----@param str string
-local function SubstituteString(str, ...)
-    local args = {...}
-    local result = str
-    for k, v in pairs(args) do
-        result = result:gsub("%["..tostring(k).."%]", v)
-    end
-    return result
 end
 
 ---@param character EsvCharacter
 ---@param skill string
 ---@param tooltip TooltipData
 local function OnStatTooltip(character, stat, tooltip)
-
-    -- Ext.Print(Ext.JsonStringify(tooltip))
     
     local stat = tooltip:GetElement("StatName").Label
     local statsPointValue = tooltip:GetElement("StatsPointValue")
 
     local attrBonus = CharGetDGMAttributeBonus(character, 0)
 
-    local str = nil
-    if dynamicTooltips[stat] then
-        str = Ext.GetTranslatedString(dynamicTooltips[stat], "Handle Error!")
-    end
-
     if stat == "Strength" then
-        str = SubstituteString(str, attrBonus["str"], attrBonus["strGlobal"], attrBonus["strWeapon"], attrBonus["strDot"])
-        statsPointValue.Label = str
+        statsPointValue.Label = GetDynamicTranslationString(stat, attrBonus["str"], attrBonus["strGlobal"], attrBonus["strWeapon"], attrBonus["strDot"])
+
     elseif stat == "Finesse" then
-        str = SubstituteString(str, attrBonus["fin"], attrBonus["finGlobal"], attrBonus["finDodge"], attrBonus["finMovement"])
-        statsPointValue.Label = str
+        statsPointValue.Label = GetDynamicTranslationString(stat, attrBonus["fin"], attrBonus["finGlobal"], attrBonus["finDodge"], attrBonus["finMovement"])
+
     elseif stat == "Intelligence" then
-        str = SubstituteString(str, attrBonus["int"], attrBonus["intGlobal"], attrBonus["intSkill"], attrBonus["intAcc"])
-        statsPointValue.Label = str
+        statsPointValue.Label = GetDynamicTranslationString(stat, attrBonus["int"], attrBonus["intGlobal"], attrBonus["intSkill"], attrBonus["intAcc"])
+
     elseif stat == "Damage" then
         local damageText = tooltip:GetElement("StatsTotalDamage")
         local minDamage = damageText.Label:gsub("^.* ", ""):gsub("-[1-9]*", "")
@@ -120,11 +148,9 @@ local function OnStatTooltip(character, stat, tooltip)
         minDamage = math.floor(tonumber(minDamage) * (100+attrBonus["strGlobal"]+attrBonus["strWeapon"]+attrBonus["finGlobal"]+attrBonus["intGlobal"])/100)
         maxDamage = math.floor(tonumber(maxDamage) * (100+attrBonus["strGlobal"]+attrBonus["strWeapon"]+attrBonus["finGlobal"]+attrBonus["intGlobal"])/100)
         
-        str = SubstituteString(str, minDamage, maxDamage)
-        damageText.Label = str
+        damageText.Label = GetDynamicTranslationString(stat, minDamage, maxDamage)
     end
 
-    -- Ext.Print(Ext.JsonStringify(tooltip))
 end
 
 ---@param character EsvCharacter
@@ -138,67 +164,43 @@ local function OnAbilityTooltip(character, stat, tooltip)
     local attrBonusNew = CharGetDGMAttributeBonus(character, 1)
     local stats = character.Stats
 
-    local str = ""
-
     if stat == "Dual-Wielding" then
 
         if stats.DualWielding > 0 then
-            str = Ext.GetTranslatedString(dynamicTooltips[stat].current, "Handle Error!")
-            str = SubstituteString(str, stats.DualWielding, attrBonus["dual"], attrBonus["dualDodge"], attrBonus["dualOff"])
-            abilityDescription.CurrentLevelEffect = str
+            abilityDescription.CurrentLevelEffect = GetDynamicTranslationString(stat, stats.DualWielding, attrBonus["dual"], attrBonus["dualDodge"], attrBonus["dualOff"])
         end
         
-        str = Ext.GetTranslatedString(dynamicTooltips[stat].new, "Handle Error!")
-        str = SubstituteString(str, stats.DualWielding+1, attrBonusNew["dual"], attrBonusNew["dualDodge"], attrBonusNew["dualOff"])
-        abilityDescription.NextLevelEffect = str
+        abilityDescription.NextLevelEffect = GetDynamicTranslationString(stat.."_Next", stats.DualWielding+1, attrBonusNew["dual"], attrBonusNew["dualDodge"], attrBonusNew["dualOff"])
         
     elseif stat == "Ranged" then
         if stats.Ranged > 0 then
-            str = Ext.GetTranslatedString(dynamicTooltips[stat].current, "Handle Error!")
-            str = SubstituteString(str, stats.Ranged, attrBonus["ranged"], attrBonus["rangedCrit"], attrBonus["rangedRange"])
-            abilityDescription.CurrentLevelEffect = str
+            abilityDescription.CurrentLevelEffect = GetDynamicTranslationString(stat, stats.Ranged, attrBonus["ranged"], attrBonus["rangedCrit"], attrBonus["rangedRange"])
         end
         
-        str = Ext.GetTranslatedString(dynamicTooltips[stat].new, "Handle Error!")
-        str = SubstituteString(str, stats.Ranged+1, attrBonusNew["ranged"], attrBonusNew["rangedCrit"], attrBonusNew["rangedRange"])
-        abilityDescription.NextLevelEffect = str
+        abilityDescription.NextLevelEffect = GetDynamicTranslationString(stat.."_Next", stats.Ranged+1, attrBonusNew["ranged"], attrBonusNew["rangedCrit"], attrBonusNew["rangedRange"])
 
     elseif stat == "Single-Handed" then
         if stats.SingleHanded > 0 then
-            str = Ext.GetTranslatedString(dynamicTooltips[stat].current, "Handle Error!")
-            str = SubstituteString(str, stats.SingleHanded, attrBonus["single"], attrBonus["singleAcc"], attrBonus["singleArm"], attrBonus["singleEle"])
-            abilityDescription.CurrentLevelEffect = str
+            abilityDescription.CurrentLevelEffect = GetDynamicTranslationString(stat, stats.SingleHanded, attrBonus["single"], attrBonus["singleAcc"], attrBonus["singleArm"], attrBonus["singleEle"])
         end
-        
-        str = Ext.GetTranslatedString(dynamicTooltips[stat].new, "Handle Error!")
-        str = SubstituteString(str, stats.SingleHanded+1, attrBonusNew["single"], attrBonusNew["singleAcc"], attrBonusNew["singleArm"], attrBonusNew["singleEle"])
-        abilityDescription.NextLevelEffect = str
+
+        abilityDescription.NextLevelEffect = GetDynamicTranslationString(stat, stats.SingleHanded+1, attrBonusNew["single"], attrBonusNew["singleAcc"], attrBonusNew["singleArm"], attrBonusNew["singleEle"])
         
     elseif stat == "Two-Handed" then
         if stats.TwoHanded > 0 then
-            str = Ext.GetTranslatedString(dynamicTooltips[stat].current, "Handle Error!")
-            str = SubstituteString(str, stats.TwoHanded, attrBonus["two"], attrBonus["twoCrit"], attrBonus["twoAcc"])
-            abilityDescription.CurrentLevelEffect = str
+            abilityDescription.CurrentLevelEffect = GetDynamicTranslationString(stat, stats.TwoHanded, attrBonus["two"], attrBonus["twoCrit"], attrBonus["twoAcc"])
         end
-        
-        str = Ext.GetTranslatedString(dynamicTooltips[stat].new, "Handle Error!")
-        str = SubstituteString(str, stats.TwoHanded+1, attrBonusNew["two"], attrBonusNew["twoCrit"], attrBonusNew["twoAcc"])
-        abilityDescription.NextLevelEffect = str
+
+        abilityDescription.NextLevelEffect =  GetDynamicTranslationString(stat, stats.TwoHanded+1, attrBonusNew["two"], attrBonusNew["twoCrit"], attrBonusNew["twoAcc"])
 
     elseif stat == "Perseverance" then
         if stats.Perseverance > 0 then
-            str = Ext.GetTranslatedString(dynamicTooltips[stat].current, "Handle Error!")
-            str = SubstituteString(str, stats.Perseverance, attrBonus["persArm"], attrBonus["persVit"])
-            abilityDescription.CurrentLevelEffect = str
+            abilityDescription.CurrentLevelEffect = GetDynamicTranslationString(stat, stats.Perseverance, attrBonus["persArm"], attrBonus["persVit"])
         end
         
-        str = Ext.GetTranslatedString(dynamicTooltips[stat].new, "Handle Error!")
-        str = SubstituteString(str, stats.Perseverance+1, attrBonusNew["persArm"], attrBonusNew["persVit"])
-        abilityDescription.NextLevelEffect = str
+        abilityDescription.NextLevelEffect = GetDynamicTranslationString(stat, stats.Perseverance+1, attrBonusNew["persArm"], attrBonusNew["persVit"])
 
     end
-
-    -- Ext.Print(Ext.JsonStringify(tooltip))
 end
 
 local function DGM_Init()

--- a/Public/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Stats/Generated/Data/Data.txt
+++ b/Public/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Stats/Generated/Data/Data.txt
@@ -148,3 +148,5 @@ key "DGM_PerseveranceVitalityRecovery","2"
 
 key "AbilityPerseveranceArmorPerPoint","8"
 
+key "DGM_RangedCQBPenaltyRange","2"
+


### PR DESCRIPTION
A skill that does 9-11 damage with a multiplier of 3 would give a discrete set of damage outputs of 27, 30, or 33. This change aims to address that and give a continuous output of 27-33.

Disables randomization in early parts of the skill damage calculation, and then applies them at the end after multiplications.

Also made the last of the tooltips localisable, fixing a mismatch between the shown value of Dual Wielding penalty and the actual damage provided. 