### PR TITLE
Update StatsPatching.lua

### DIFF
--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/Shared/StatsPatching.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/Shared/StatsPatching.lua
@@ -220,9 +220,9 @@ end
 local function AttributeCap()
 	local hardSaved = Ext.LoadFile("LeaderLib_GlobalSettings.json")
 	if hardSaved ~= nil then
-		local variables = Ext.JsonParse(hardSaved).Mods["3ff156e2-289e-4dac-81f5-a44e3e304163"].Global.Flags
-		if variables.LXDGM_AttributeCap then
-			Ext.ExtraData.AttributeSoftCap = variables.LXDGM_AttributeCap
+		local variables = Ext.JsonParse(hardSaved).Mods["3ff156e2-289e-4dac-81f5-a44e3e304163"].Global.Variables
+		if variables.AttributeCap then
+			Ext.ExtraData.AttributeSoftCap = variables.AttributeCap
 		end
 	end
 end

--- a/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/Shared/StatsPatching.lua
+++ b/Mods/lx_enhanced_divine_combat_3ff156e2-289e-4dac-81f5-a44e3e304163/Story/RawFiles/Lua/Shared/StatsPatching.lua
@@ -222,7 +222,7 @@ local function AttributeCap()
 	if hardSaved ~= nil then
 		local variables = Ext.JsonParse(hardSaved).Mods["3ff156e2-289e-4dac-81f5-a44e3e304163"].Global.Variables
 		if variables.AttributeCap then
-			Ext.ExtraData.AttributeSoftCap = variables.AttributeCap
+			Ext.ExtraData.AttributeSoftCap = variables.AttributeCap.Value
 		end
 	end
 end


### PR DESCRIPTION
GlobalSettings stores the attribute cap information under the Variables property, rather than the Flags property. This PR updates the `AttributeCap` function to reference the correct property in the settings file.